### PR TITLE
fix: problem module should no longer generate stack traces in rest ca…

### DIFF
--- a/src/main/java/org/cardanofoundation/lob/app/LobServiceApp.java
+++ b/src/main/java/org/cardanofoundation/lob/app/LobServiceApp.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
@@ -43,6 +44,7 @@ import java.time.Clock;
 @EnableTransactionManagement
 @EnableAsync
 //@ImportRuntimeHints(LobServiceApp.Hints.class)
+@EnableAutoConfiguration
 @Slf4j
 @RequiredArgsConstructor
 public class LobServiceApp {

--- a/src/main/java/org/cardanofoundation/lob/app/support/web/internal/JsonConfig.java
+++ b/src/main/java/org/cardanofoundation/lob/app/support/web/internal/JsonConfig.java
@@ -1,27 +1,29 @@
 package org.cardanofoundation.lob.app.support.web.internal;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.zalando.problem.jackson.ProblemModule;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 
 @Configuration
+@Slf4j
 public class JsonConfig {
 
     @Bean
-    @Primary
-    public ObjectMapper jsonMapper() {
-        return new ObjectMapper()
-                .setSerializationInclusion(NON_NULL)
-                .enable(ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
-                .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-                .registerModules(new JavaTimeModule(), new Jdk8Module());
+    public Jackson2ObjectMapperBuilder jackson2ObjectMapperBuilder(ProblemModule problem) {
+        log.info("Configuring Jackson2ObjectMapperBuilder");
+
+        return new Jackson2ObjectMapperBuilder()
+                .serializationInclusion(JsonInclude.Include.NON_NULL)
+                .featuresToEnable(ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, FAIL_ON_UNKNOWN_PROPERTIES)
+                .modulesToInstall(new JavaTimeModule(), new Jdk8Module(), problem);
     }
 
 }


### PR DESCRIPTION
Supress stacktraces serialised to the output in http responses. This is cluttering the response and not recommended for security reasons. 

Responses should look like this now (as one sees there is no stacktrace):
![image](https://github.com/cardano-foundation/cf-lob/assets/335933/bdc0e6a4-ce4a-4599-b608-cf03de9d758f)
