### PR TITLE
refak: encapsulation for db mapping type (move away from domain).

### DIFF
--- a/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/core/TransactionType.java
+++ b/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/core/TransactionType.java
@@ -2,25 +2,15 @@ package org.cardanofoundation.lob.app.accounting_reporting_core.domain.core;
 
 public enum TransactionType {
 
-    CardCharge(1),
-    VendorBill(2),
-    CardRefund(4),
-    Journal(8),
-    FxRevaluation(16),
-    Transfer(32),
-    CustomerPayment(64),
-    ExpenseReport(128),
-    VendorPayment(256),
-    BillCredit(512);
-
-    private int value;
-
-    TransactionType(int value) {
-        this.value = value;
-    }
-
-    public int getValue() {
-        return value;
-    }
+    CardCharge,
+    VendorBill,
+    CardRefund,
+    Journal,
+    FxRevaluation,
+    Transfer,
+    CustomerPayment,
+    ExpenseReport,
+    VendorPayment,
+    BillCredit;
 
 }

--- a/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/entity/TransactionTypeConverter.java
+++ b/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/entity/TransactionTypeConverter.java
@@ -7,9 +7,12 @@ import org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.Trans
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 @Converter(autoApply = true)
 public class TransactionTypeConverter implements AttributeConverter<List<TransactionType>, Integer> {
+
+    private static final Function<TransactionType, Integer> typeToNumber = TransactionTypeMapper.createTypeToNumber();
 
     @Override
     public Integer convertToDatabaseColumn(List<TransactionType> attribute) {
@@ -19,7 +22,7 @@ public class TransactionTypeConverter implements AttributeConverter<List<Transac
 
         int value = 0;
         for (val type : attribute) {
-            value |= type.getValue();
+            value |= typeToNumber.apply(type);
         }
 
         return value;
@@ -33,7 +36,9 @@ public class TransactionTypeConverter implements AttributeConverter<List<Transac
 
         List<TransactionType> transactionTypes = new ArrayList<>();
         for (val type : TransactionType.values()) {
-            if ((dbData & type.getValue()) == type.getValue()) {
+            val typeValue = typeToNumber.apply(type);
+
+            if ((dbData & typeValue) == typeValue) {
                 transactionTypes.add(type);
             }
         }

--- a/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/entity/TransactionTypeMapper.java
+++ b/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/entity/TransactionTypeMapper.java
@@ -1,0 +1,26 @@
+package org.cardanofoundation.lob.app.accounting_reporting_core.domain.entity;
+
+import org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.TransactionType;
+
+import java.util.function.Function;
+
+public final class TransactionTypeMapper {
+
+    public static Function<TransactionType, Integer> createTypeToNumber() {
+        return type -> {
+            return switch(type) {
+                case CardCharge -> 1;
+                case VendorBill -> 2;
+                case CardRefund -> 4;
+                case Journal -> 8;
+                case FxRevaluation -> 16;
+                case Transfer -> 32;
+                case CustomerPayment -> 64;
+                case ExpenseReport -> 128;
+                case VendorPayment -> 256;
+                case BillCredit -> 512;
+            };
+        };
+    }
+
+}

--- a/src/test/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/entity/TransactionTypeMapperTest.java
+++ b/src/test/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/entity/TransactionTypeMapperTest.java
@@ -1,0 +1,27 @@
+package org.cardanofoundation.lob.app.accounting_reporting_core.domain.entity;
+
+import lombok.val;
+import org.junit.jupiter.api.Test;
+
+import static org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.TransactionType.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TransactionTypeMapperTest {
+
+    @Test
+    void testApply() {
+        val transactionTypeMapper = TransactionTypeMapper.createTypeToNumber();
+
+        assertEquals(1, transactionTypeMapper.apply(CardCharge));
+        assertEquals(2, transactionTypeMapper.apply(VendorBill));
+        assertEquals(4, transactionTypeMapper.apply(CardRefund));
+        assertEquals(8, transactionTypeMapper.apply(Journal));
+        assertEquals(16, transactionTypeMapper.apply(FxRevaluation));
+        assertEquals(32, transactionTypeMapper.apply(Transfer));
+        assertEquals(64, transactionTypeMapper.apply(CustomerPayment));
+        assertEquals(128, transactionTypeMapper.apply(ExpenseReport));
+        assertEquals(256, transactionTypeMapper.apply(VendorPayment));
+        assertEquals(512, transactionTypeMapper.apply(BillCredit));
+    }
+
+}


### PR DESCRIPTION
It was never an intention for these "value" numbers to be part of the core domain of LOB. At the moment these values are only needed so that we can efficiently (without using extra mapping table in db) store multiple types inside of one db column.

This task is about refactoring out "value" as integer towards db layer only, away from the business domain.