### PR TITLE
fix: fixed bug related to not pulling transaction status OK from data…

### DIFF
--- a/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/core/TransactionStatus.java
+++ b/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/core/TransactionStatus.java
@@ -2,6 +2,6 @@ package org.cardanofoundation.lob.app.accounting_reporting_core.domain.core;
 
 public enum TransactionStatus {
 
-    FAIL, SUCCESS
+    FAIL, OK
 
 }

--- a/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/entity/TransactionEntity.java
+++ b/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/entity/TransactionEntity.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.EAGER;
 import static org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.LedgerDispatchStatus.NOT_DISPATCHED;
-import static org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.TransactionStatus.SUCCESS;
+import static org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.TransactionStatus.OK;
 import static org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.ValidationStatus.FAILED;
 
 @Getter
@@ -160,7 +160,7 @@ public class TransactionEntity extends AuditEntity implements Persistable<String
     }
 
     public boolean isDispatchable() {
-        return status == SUCCESS
+        return status == OK
                 && ledgerDispatchStatus == NOT_DISPATCHED;
     }
 

--- a/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/entity/TransactionEntityListener.java
+++ b/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/entity/TransactionEntityListener.java
@@ -5,7 +5,7 @@ import jakarta.persistence.PreUpdate;
 import org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.TransactionStatus;
 
 import static org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.TransactionStatus.FAIL;
-import static org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.TransactionStatus.SUCCESS;
+import static org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.TransactionStatus.OK;
 import static org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.ValidationStatus.VALIDATED;
 
 public class TransactionEntityListener {
@@ -15,7 +15,7 @@ public class TransactionEntityListener {
                 && transactionEntity.isRejectionFree()
                 && transactionEntity.getAutomatedValidationStatus() == VALIDATED
         ) {
-            return SUCCESS;
+            return OK;
         }
 
         return FAIL;

--- a/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/job/TransactionDispatcherJob.java
+++ b/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/job/TransactionDispatcherJob.java
@@ -1,11 +1,7 @@
 package org.cardanofoundation.lob.app.accounting_reporting_core.job;
 
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.cardanofoundation.lob.app.accounting_reporting_core.repository.TransactionBatchRepositoryGateway;
-import org.cardanofoundation.lob.app.accounting_reporting_core.repository.TransactionRepositoryGateway;
-import org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.AccountingCoreService;
 import org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.LedgerService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -14,9 +10,6 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @RequiredArgsConstructor
 public class TransactionDispatcherJob {
-    private final TransactionRepositoryGateway transactionRepositoryGateway;
-    private final AccountingCoreService accountingCoreService;
-    private final TransactionBatchRepositoryGateway transactionBatchRepositoryGateway;
     private final LedgerService ledgerService;
 
     @Scheduled(fixedDelayString = "PT1M", initialDelayString = "PT10S")

--- a/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/views/TransactionView.java
+++ b/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/views/TransactionView.java
@@ -32,6 +32,6 @@ public class TransactionView {
     private boolean ledgerDispatchApproved = false;
     private Set<TransactionItemView> items = new LinkedHashSet<>();
     private Set<ViolationView> violations = new LinkedHashSet<>();
-    private TransactionStatus status = TransactionStatus.SUCCESS;
+    private TransactionStatus status = TransactionStatus.OK;
 
 }

--- a/src/main/java/org/cardanofoundation/lob/app/blockchain_publisher/service/MetadataSerialiser.java
+++ b/src/main/java/org/cardanofoundation/lob/app/blockchain_publisher/service/MetadataSerialiser.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigInteger;
 import java.time.Clock;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Set;
 
@@ -49,7 +49,7 @@ public class MetadataSerialiser {
     private MetadataMap createMetadataSection(long creationSlot) {
         val metadataMap = MetadataBuilder.createMap();
 
-        val now = LocalDateTime.now(clock);
+        val now = Instant.now(clock);
 
         metadataMap.put("creation_slot", BigInteger.valueOf(creationSlot));
         metadataMap.put("timestamp", DateTimeFormatter.ISO_INSTANT.format(now));

--- a/src/test/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/entity/TransactionEntityListenerTest.java
+++ b/src/test/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/entity/TransactionEntityListenerTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.TransactionStatus.FAIL;
-import static org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.TransactionStatus.SUCCESS;
+import static org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.TransactionStatus.OK;
 import static org.mockito.Mockito.*;
 
 public class TransactionEntityListenerTest {
@@ -30,7 +30,7 @@ public class TransactionEntityListenerTest {
 
         TransactionStatus status = listener.calcStatus(transactionEntity);
 
-        assertThat(status).isEqualTo(SUCCESS);
+        assertThat(status).isEqualTo(OK);
     }
 
     @Test
@@ -74,7 +74,7 @@ public class TransactionEntityListenerTest {
 
         listener.update(transactionEntity);
 
-        verify(transactionEntity).setStatus(SUCCESS);
+        verify(transactionEntity).setStatus(OK);
     }
 
     @Test


### PR DESCRIPTION
Two bugs were found and fixed:
- we were pulling transactions with status: "OK" but actually transaction was: "SUCCESS"
- formatting for on-chain date didn't work correctly, we have to use Instant.now for this instead of LocalDateTime