### PR TITLE
fix: fixed typo in Kafka consumer hindering to update tx status

### DIFF
--- a/cf-application/src/main/java/org/cardanofoundation/lob/app/kafka/AccountingCoreKafkaConsumer.java
+++ b/cf-application/src/main/java/org/cardanofoundation/lob/app/kafka/AccountingCoreKafkaConsumer.java
@@ -19,12 +19,12 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-@ConditionalOnProperty(value = {"lob.accounting_reporting_core.enabled", "spring.kafka.enabled"}, havingValue = "true")
+@ConditionalOnProperty(value = {"lob.accounting_reporting_core.enabled", "spring.kafka.enabled"}, havingValue = "true", matchIfMissing = true)
 public class AccountingCoreKafkaConsumer {
 
     private final ApplicationEventPublisher applicationEventPublisher;
 
-    @KafkaListener(topics = "accounting_reporting_core.domain.event.ledger.TxsLedgerUpdateEvent")
+    @KafkaListener(topics = "accounting_reporting_core.domain.event.ledger.TxsLedgerUpdatedEvent")
     public void listen(TxsLedgerUpdatedEvent message) {
         applicationEventPublisher.publishEvent(message);
     }

--- a/cf-application/src/main/java/org/cardanofoundation/lob/app/kafka/BlockchainPublisherKafkaConsumer.java
+++ b/cf-application/src/main/java/org/cardanofoundation/lob/app/kafka/BlockchainPublisherKafkaConsumer.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-@ConditionalOnProperty(value = {"lob.blockchain_publisher.enabled", "spring.kafka.enabled"}, havingValue = "true")
+@ConditionalOnProperty(value = {"lob.blockchain_publisher.enabled", "spring.kafka.enabled"}, havingValue = "true", matchIfMissing = true)
 public class BlockchainPublisherKafkaConsumer {
 
     private final ApplicationEventPublisher applicationEventPublisher;


### PR DESCRIPTION
This bug fixes the ticket LOB-932.
The issue was that the status of transactions weren't properly updated after being published. The problem was that there is a typo in the kafka topic. 

This PR fixes the problem