### PR TITLE
Fix/kafka rebalance

### DIFF
--- a/cf-application/src/main/java/org/cardanofoundation/lob/app/kafka/consumer/AccountingCoreKafkaConsumer.java
+++ b/cf-application/src/main/java/org/cardanofoundation/lob/app/kafka/consumer/AccountingCoreKafkaConsumer.java
@@ -24,54 +24,54 @@ public class AccountingCoreKafkaConsumer {
 
     private final ApplicationEventPublisher applicationEventPublisher;
 
-    @KafkaListener(topics = "${lob.accounting_reporting_core.topics.tx-ledger-updated-event}", groupId = "${spring.kafka.consumer.group-id}")
+    @KafkaListener(topics = "${lob.accounting_reporting_core.topics.tx-ledger-updated-event}", groupId = "${lob.accounting_reporting_core.consumer-group}")
     public void listen(TxsLedgerUpdatedEvent message) {
         applicationEventPublisher.publishEvent(message);
     }
 
-    @KafkaListener(topics = "${lob.accounting_reporting_core.topics.validate-ingestion-response-event}")
+    @KafkaListener(topics = "${lob.accounting_reporting_core.topics.validate-ingestion-response-event}", groupId = "${lob.accounting_reporting_core.consumer-group}")
     public void listen(ValidateIngestionResponseEvent message) {
         log.info("Received ValidateIngestionResponseEvent from Kafka: {}", message);
         applicationEventPublisher.publishEvent(message);
     }
 
-    @KafkaListener(topics = "${lob.accounting_reporting_core.topics.transaction-batch-failed-event}")
+    @KafkaListener(topics = "${lob.accounting_reporting_core.topics.transaction-batch-failed-event}", groupId = "${lob.accounting_reporting_core.consumer-group}")
     public void listen(TransactionBatchFailedEvent message) {
         log.info("Received TransactionBatchFailedEvent from Kafka: {}", message);
         applicationEventPublisher.publishEvent(message);
     }
 
-    @KafkaListener(topics = "${lob.accounting_reporting_core.topics.transaction-batch-started-event}")
+    @KafkaListener(topics = "${lob.accounting_reporting_core.topics.transaction-batch-started-event}", groupId = "${lob.accounting_reporting_core.consumer-group}")
     public void listen(TransactionBatchStartedEvent message) {
         log.info("Received TransactionBatchStartedEvent from Kafka: {}", message);
         applicationEventPublisher.publishEvent(message);
     }
 
-    @KafkaListener(topics = "${lob.accounting_reporting_core.topics.transaction-batch-chunk-event}")
+    @KafkaListener(topics = "${lob.accounting_reporting_core.topics.transaction-batch-chunk-event}", groupId = "${lob.accounting_reporting_core.consumer-group}")
     public void listen(TransactionBatchChunkEvent message) {
         log.info("Received TransactionBatchChunkEvent from Kafka: {}", message);
         applicationEventPublisher.publishEvent(message);
     }
 
-    @KafkaListener(topics = "${lob.accounting_reporting_core.topics.reconcilation-failed-event}")
+    @KafkaListener(topics = "${lob.accounting_reporting_core.topics.reconcilation-failed-event}", groupId = "${lob.accounting_reporting_core.consumer-group}")
     public void listen(ReconcilationFailedEvent message) {
         log.info("Received ReconcilationFailedEvent from Kafka: {}", message);
         applicationEventPublisher.publishEvent(message);
     }
 
-    @KafkaListener(topics = "${lob.accounting_reporting_core.topics.reconcilation-started-event}")
+    @KafkaListener(topics = "${lob.accounting_reporting_core.topics.reconcilation-started-event}", groupId = "${lob.accounting_reporting_core.consumer-group}")
     public void listen(ReconcilationStartedEvent message) {
         log.info("Received ReconcilationStartedEvent from Kafka: {}", message);
         applicationEventPublisher.publishEvent(message);
     }
 
-    @KafkaListener(topics = "${lob.accounting_reporting_core.topics.reconcilation-chunk-event}")
+    @KafkaListener(topics = "${lob.accounting_reporting_core.topics.reconcilation-chunk-event}", groupId = "${lob.accounting_reporting_core.consumer-group}")
     public void listen(ReconcilationChunkEvent message) {
         log.info("Received ReconcilationChunkEvent from Kafka: {}", message);
         applicationEventPublisher.publishEvent(message);
     }
 
-    @KafkaListener(topics = "${lob.accounting_reporting_core.topics.reconcilation-finalisation-event}")
+    @KafkaListener(topics = "${lob.accounting_reporting_core.topics.reconcilation-finalisation-event}", groupId = "${lob.accounting_reporting_core.consumer-group}")
     public void listen(ReconcilationFinalisationEvent message) {
         log.info("Received ReconcilationFinalisationEvent from Kafka: {}", message);
         applicationEventPublisher.publishEvent(message);

--- a/cf-application/src/main/java/org/cardanofoundation/lob/app/kafka/consumer/BlockchainPublisherKafkaConsumer.java
+++ b/cf-application/src/main/java/org/cardanofoundation/lob/app/kafka/consumer/BlockchainPublisherKafkaConsumer.java
@@ -19,25 +19,25 @@ public class BlockchainPublisherKafkaConsumer {
 
     private final ApplicationEventPublisher applicationEventPublisher;
 
-    @KafkaListener(topics = "${lob.blockchain_publisher.topics.transaction-ledger-update-commander}")
+    @KafkaListener(topics = "${lob.blockchain_publisher.topics.transaction-ledger-update-commander}", groupId = "${lob.blockchain_publisher.consumer-group}")
     public void listen(TransactionLedgerUpdateCommand message) {
         log.info("Received LedgerUpdateCommand from Kafka: {}", message);
         applicationEventPublisher.publishEvent(message);
     }
 
-    @KafkaListener(topics = "${lob.reporting.topics.publish-report-event}")
+    @KafkaListener(topics = "${lob.reporting.topics.publish-report-event}", groupId = "${lob.blockchain_publisher.consumer-group}")
     public void listen(PublishReportEvent message) {
         log.info("Received PublishReportEvent from Kafa: {}", message);
         applicationEventPublisher.publishEvent(message);
     }
 
-    @KafkaListener(topics = "${lob.blockchain_publisher.topics.tx-rollback-event}")
+    @KafkaListener(topics = "${lob.blockchain_publisher.topics.tx-rollback-event}", groupId = "${lob.blockchain_publisher.consumer-group}")
     public void listen(TxRollbackEvent message) {
         log.info("Received TxRollbackEvent from Kafa: {}", message);
         applicationEventPublisher.publishEvent(message);
     }
 
-    @KafkaListener(topics = "${lob.blockchain_publisher.topics.transaction-status-request-event}")
+    @KafkaListener(topics = "${lob.blockchain_publisher.topics.transaction-status-request-event}", groupId = "${lob.blockchain_publisher.consumer-group}")
     public void listen(TransactionStatusRequestEvent message) {
         log.info("Received TransactionStatusRequestEvent from Kafka: {}", message);
         applicationEventPublisher.publishEvent(message);

--- a/cf-application/src/main/java/org/cardanofoundation/lob/app/kafka/consumer/NetSuiteKafkaConsumer.java
+++ b/cf-application/src/main/java/org/cardanofoundation/lob/app/kafka/consumer/NetSuiteKafkaConsumer.java
@@ -22,30 +22,30 @@ public class NetSuiteKafkaConsumer {
     private final ApplicationEventPublisher applicationEventPublisher;
     private final ObjectMapper objectMapper;
 
-    @KafkaListener(topics = "${lob.netsuite.topics.scheduled-ingestion-event}")
+    @KafkaListener(topics = "${lob.netsuite.topics.scheduled-ingestion-event}", groupId = "${lob.netsuite.consumer-group}")
     public void listen(ScheduledIngestionEvent message) {
         applicationEventPublisher.publishEvent(message);
     }
 
-    @KafkaListener(topics = "${lob.netsuite.topics.validate-ingestion-event}")
+    @KafkaListener(topics = "${lob.netsuite.topics.validate-ingestion-event}", groupId = "${lob.netsuite.consumer-group}")
     public void listen(ValidateIngestionEvent message) {
         log.info("Received ValidateIngestionEvent from Kafka: {}", message);
         applicationEventPublisher.publishEvent(message);
     }
 
-    @KafkaListener(topics = "${lob.netsuite.topics.transaction-batch-created-event}")
+    @KafkaListener(topics = "${lob.netsuite.topics.transaction-batch-created-event}", groupId = "${lob.netsuite.consumer-group}")
     public void listen(TransactionBatchCreatedEvent message) {
         log.info("Received TransactionBatchCreatedEvent from Kafka: {}", message);
         applicationEventPublisher.publishEvent(message);
     }
 
-    @KafkaListener(topics = "${lob.netsuite.topics.scheduled-reconcilation-event}")
+    @KafkaListener(topics = "${lob.netsuite.topics.scheduled-reconcilation-event}", groupId = "${lob.netsuite.consumer-group}")
     public void listen(ScheduledReconcilationEvent message) {
         log.info("Received ScheduledReconcilationEvent from Kafka: {}", message);
         applicationEventPublisher.publishEvent(message);
     }
 
-    @KafkaListener(topics = "${lob.netsuite.topics.reconcilation-created-event}")
+    @KafkaListener(topics = "${lob.netsuite.topics.reconcilation-created-event}", groupId = "${lob.netsuite.consumer-group}")
     public void listen(ReconcilationCreatedEvent message) {
         log.info("Received ReconcilationCreatedEvent from Kafka: {}", message);
         applicationEventPublisher.publishEvent(message);

--- a/cf-application/src/main/java/org/cardanofoundation/lob/app/kafka/consumer/ReportingKafkaConsumer.java
+++ b/cf-application/src/main/java/org/cardanofoundation/lob/app/kafka/consumer/ReportingKafkaConsumer.java
@@ -16,7 +16,7 @@ public class ReportingKafkaConsumer {
 
     private final ApplicationEventPublisher applicationEventPublisher;
 
-    @KafkaListener(topics = "${lob.reporting.topics.reports-ledger-updated-event}")
+    @KafkaListener(topics = "${lob.reporting.topics.reports-ledger-updated-event}", groupId = "${lob.reporting.consumer-group}")
     public void listen(ReportsLedgerUpdatedEvent message) {
         log.info("Received ReportsLedgerUpdatedEvent from Kafka: {}", message);
         applicationEventPublisher.publishEvent(message);

--- a/cf-application/src/main/resources/application-prod.yml
+++ b/cf-application/src/main/resources/application-prod.yml
@@ -12,7 +12,7 @@ management:
     health:
       show-details: when-authorized
     threaddump:
-      enabled: false
+      access: none
 
 lob:
   netsuite:

--- a/cf-application/src/main/resources/application-prod.yml
+++ b/cf-application/src/main/resources/application-prod.yml
@@ -19,3 +19,9 @@ lob:
     financial:
       period:
         source: IMPLICIT
+
+logging:
+ level:
+   org.apache.kafka.clients.consumer.ConsumerConfig: WARN
+   org.apache.kafka.clients.producer.ProducerConfig: WARN
+

--- a/cf-application/src/main/resources/application.yml
+++ b/cf-application/src/main/resources/application.yml
@@ -50,7 +50,6 @@ spring:
         # KIP-848: Use the new consumer group protocol for incremental cooperative rebalancing.
         # This replaces the classic stop-the-world rebalances.
         group.protocol: consumer
-        partition.assignment.strategy: org.apache.kafka.clients.consumer.CooperativeStickyAssignor
         spring:
           json:
             trusted:

--- a/cf-application/src/main/resources/application.yml
+++ b/cf-application/src/main/resources/application.yml
@@ -13,19 +13,19 @@ management:
       probes:
         enabled: true
     env:
-      enabled: false
+      access: none
     configprops:
-      enabled: false
+      access: none
     heapdump:
-      enabled: false
+      access: none
     mappings:
-      enabled: false
+      access: none
     loggers:
-      enabled: false
+      access: none
     conditions:
-      enabled: false
+      access: none
     beans:
-      enabled: false
+      access: none
   metrics:
     enable:
       all: true
@@ -41,10 +41,19 @@ spring:
     enabled: true
     bootstrap-servers: kafka:9092
     consumer:
-      group-id: lob-consumer
+      # No global group-id — each @KafkaListener gets its own group to avoid
+      # cross-topic rebalance storms during rolling updates.
+      # group-id must be set explicitly on each @KafkaListener or via per-module properties.
       auto-offset-reset: latest
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
+        # KIP-848: Use the new consumer group protocol for incremental cooperative rebalancing.
+        # This avoids the stop-the-world rebalances of the classic protocol.
+        group.protocol: consumer
+        # Static group membership: assign a stable instance id (derived from the pod hostname)
+        # so that restarted consumers reclaim their partitions without triggering a rebalance.
+        group.instance.id: ${CONSUMER_INSTANCE_ID:${HOSTNAME:unknown}}
+        partition.assignment.strategy: org.apache.kafka.clients.consumer.CooperativeStickyAssignor
         spring:
           json:
             trusted:
@@ -56,8 +65,9 @@ spring:
       auto-commit-interval: 1000
     producer:
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-      retries: 0
+      retries: 5
       properties:
+        enable.idempotence: true
         max:
           request:
             size: 15728640 # 15MB
@@ -168,6 +178,7 @@ lob:
         stuck_delay: ${LOB_ACCOUNTING_REPORTING_CORE_JOBS_UNSTUCK_STUCK_DELAY:PT10M}
     debounce:
       duration: ${LOB_ACCOUNTING_REPORTING_CORE_DEBOUNCE_DURATION:PT10S}
+    consumer-group: lob-consumer-accounting-core
     topics:
       tx-ledger-updated-event: accounting_reporting_core.domain.event.ledger.TxsLedgerUpdatedEvent
 
@@ -195,8 +206,8 @@ lob:
       enabled: ${LOB_BLOCKCHAIN_PUBLISHER_ROLLBACK_ENABLED:false}
     enabled: ${LOB_BLOCKCHAIN_PUBLISHER_ENABLED:false}
     maxDelay: ${LOB_BLOCKCHAIN_PUBLISHER_MAX_DELAY:PT5M}
+    consumer-group: lob-consumer-blockchain-publisher
     topics:
-      report-ledger-update-command: accounting_reporting_core.domain.event.ledger.ReportLedgerUpdateCommand
       transaction-ledger-update-commander: accounting_reporting_core.domain.event.ledger.TransactionLedgerUpdateCommand
       transaction-status-request-event: accounting_reporting_core.domain.event.ledger.TransactionStatusRequestEvent
       tx-rollback-event: accounting_reporting_core.domain.event.ledger.TxRollbackEvent
@@ -211,8 +222,8 @@ lob:
         role: ${LOB_BLOCKCHAIN_PUBLISHER_KERI_IDENTIFIER_ROLE:agent}
   reporting:
     enabled: ${LOB_REPORTING_ENABLED:false}
+    consumer-group: lob-consumer-reporting
     topics:
-      publish-report-event: reporting.dto.events.PublishReportEvent
       reports-ledger-updated-event: reporting.dto.events.ReportsLedgerUpdatedEvent
   cors:
     allowed:
@@ -226,8 +237,8 @@ lob:
     financial:
       period:
         source: EXPLICIT
+    consumer-group: lob-consumer-netsuite
     topics:
-      scheduled-ingestion-event: accounting_reporting_core.domain.event.extraction.ScheduledIngestionEvent
       validate-ingestion-event: accounting_reporting_core.domain.event.extraction.ValidateIngestionEvent
       transaction-batch-created-event: accounting_reporting_core.domain.event.extraction.TransactionBatchCreatedEvent
       scheduled-reconcilation-event: accounting_reporting_core.domain.event.reconcilation.ScheduledReconcilationEvent

--- a/cf-application/src/main/resources/application.yml
+++ b/cf-application/src/main/resources/application.yml
@@ -48,11 +48,8 @@ spring:
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
         # KIP-848: Use the new consumer group protocol for incremental cooperative rebalancing.
-        # This avoids the stop-the-world rebalances of the classic protocol.
+        # This replaces the classic stop-the-world rebalances.
         group.protocol: consumer
-        # Static group membership: assign a stable instance id (derived from the pod hostname)
-        # so that restarted consumers reclaim their partitions without triggering a rebalance.
-        group.instance.id: ${CONSUMER_INSTANCE_ID:${HOSTNAME:unknown}}
         partition.assignment.strategy: org.apache.kafka.clients.consumer.CooperativeStickyAssignor
         spring:
           json:
@@ -224,6 +221,7 @@ lob:
     enabled: ${LOB_REPORTING_ENABLED:false}
     consumer-group: lob-consumer-reporting
     topics:
+      publish-report-event: reporting.dto.events.PublishReportEvent
       reports-ledger-updated-event: reporting.dto.events.ReportsLedgerUpdatedEvent
   cors:
     allowed:
@@ -239,6 +237,7 @@ lob:
         source: EXPLICIT
     consumer-group: lob-consumer-netsuite
     topics:
+      scheduled-ingestion-event: accounting_reporting_core.domain.event.extraction.ScheduledIngestionEvent
       validate-ingestion-event: accounting_reporting_core.domain.event.extraction.ValidateIngestionEvent
       transaction-batch-created-event: accounting_reporting_core.domain.event.extraction.TransactionBatchCreatedEvent
       scheduled-reconcilation-event: accounting_reporting_core.domain.event.reconcilation.ScheduledReconcilationEvent


### PR DESCRIPTION
Rolling updates in Kubernetes would fail from time to time resulting in longer downtime. The reason seems to have been our Kafka topic setup. Up until now we would create a group for all of our consumers which could lead to long lasting rebalancing issues on rolling updates where the old pod was still running and the new pod was starting and trying to register as new consumers. 